### PR TITLE
Correct on disconnect

### DIFF
--- a/ble_icm_20948_peripheral/main.c
+++ b/ble_icm_20948_peripheral/main.c
@@ -472,6 +472,8 @@ static void ble_evt_handler(ble_evt_t const * p_ble_evt, void * p_context)
         case BLE_GAP_EVT_DISCONNECTED:
             NRF_LOG_INFO("Disconnected.");
             inv_icm20948_set_sleep_mode(true);
+            m_service.is_imu_data_notification_enabled = false;
+            nrf_gpio_pin_clear(PIN_OUT);
             // LED indication will be changed when advertising starts
             break;
 


### PR DESCRIPTION
Corrected the handling when the central disconnects unexpectedly, i.e. central gets powered down without disconneting first.