### PR TITLE
Update central with Run/Stop

### DIFF
--- a/ble_icm_20948_central/ble_nus_c.c
+++ b/ble_icm_20948_central/ble_nus_c.c
@@ -232,7 +232,7 @@ static uint32_t cccd_configure(ble_nus_c_t * p_ble_nus_c, bool notification_enab
 }
 
 
-uint32_t ble_nus_c_tx_notif_enable(ble_nus_c_t * p_ble_nus_c)
+uint32_t ble_nus_c_tx_notif_enable(ble_nus_c_t * p_ble_nus_c, bool notify)
 {
     VERIFY_PARAM_NOT_NULL(p_ble_nus_c);
 
@@ -242,7 +242,7 @@ uint32_t ble_nus_c_tx_notif_enable(ble_nus_c_t * p_ble_nus_c)
     {
         return NRF_ERROR_INVALID_STATE;
     }
-    return cccd_configure(p_ble_nus_c, true);
+    return cccd_configure(p_ble_nus_c, notify);
 }
 
 

--- a/ble_icm_20948_central/ble_nus_c.h
+++ b/ble_icm_20948_central/ble_nus_c.h
@@ -230,7 +230,7 @@ void ble_nus_c_on_ble_evt(ble_evt_t const * p_ble_evt, void * p_context);
  * @retval  NRF_SUCCESS If the operation was successful. 
  * @retval  err_code 	Otherwise, this API propagates the error code returned by function @ref nrf_ble_gq_item_add.
  */
-uint32_t ble_nus_c_tx_notif_enable(ble_nus_c_t * p_ble_nus_c);
+uint32_t ble_nus_c_tx_notif_enable(ble_nus_c_t * p_ble_nus_c, bool notify);
 
 
 /**@brief Function for sending a string to the server.

--- a/ble_icm_20948_central/main.c
+++ b/ble_icm_20948_central/main.c
@@ -353,6 +353,7 @@ void uart_event_handle(app_uart_evt_t * p_event)
                 (data_array[index - 1] == '\r') ||
                 (index >= (m_ble_nus_max_data_len)))
             {
+                /*
                 NRF_LOG_DEBUG("Ready to send data over BLE NUS");
                 NRF_LOG_HEXDUMP_DEBUG(data_array, index);
 
@@ -364,6 +365,22 @@ void uart_event_handle(app_uart_evt_t * p_event)
                         APP_ERROR_CHECK(ret_val);
                     }
                 } while (ret_val == NRF_ERROR_RESOURCES);
+                */
+
+                ret_val = NRF_SUCCESS;  // initialize to good value in case user input something other than r/s
+                if ((index >= 2) && ((data_array[0] == 'r') || (data_array[0] == 'R')))
+                {
+                    ret_val = ble_nus_c_tx_notif_enable(&m_ble_nus_c, true);
+                }
+                else if ((index >= 2) && ((data_array[0] == 's') || (data_array[0] == 'S')))
+                {
+                    ret_val = ble_nus_c_tx_notif_enable(&m_ble_nus_c, false);
+                }
+                if ((ret_val != NRF_SUCCESS) && (ret_val != NRF_ERROR_BUSY))
+                {
+                    NRF_LOG_ERROR("ble_nus_c_tx_notif_enable() failed to set notify");
+                    APP_ERROR_CHECK(ret_val);
+                }
 
                 index = 0;
             }
@@ -406,7 +423,7 @@ static void ble_nus_c_evt_handler(ble_nus_c_t * p_ble_nus_c, ble_nus_c_evt_t con
             err_code = ble_nus_c_handles_assign(p_ble_nus_c, p_ble_nus_evt->conn_handle, &p_ble_nus_evt->handles);
             APP_ERROR_CHECK(err_code);
 
-            err_code = ble_nus_c_tx_notif_enable(p_ble_nus_c);
+            err_code = ble_nus_c_tx_notif_enable(p_ble_nus_c, false);
             APP_ERROR_CHECK(err_code);
             NRF_LOG_INFO("Connected to device with Nordic UART Service.");
             break;


### PR DESCRIPTION
Enabled the ability to send the central device a Run or Stop command through the uart.

Sending either r/R will set notify for the imu data so that the peripheral will send imu data.
Sending either s/S will clear notify for the imu data so that the peripheral will not send imu data.