### PR TITLE
Restructure code

### DIFF
--- a/ble_icm_20948_central/main.c
+++ b/ble_icm_20948_central/main.c
@@ -40,6 +40,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
+
 #include "nordic_common.h"
 #include "app_error.h"
 #include "app_uart.h"
@@ -63,13 +64,11 @@
 #include "nrf_log_default_backends.h"
 
 #include "imu.h"
+#include "uart.h"
 
 
 #define APP_BLE_CONN_CFG_TAG    1                                       /**< Tag that refers to the BLE stack configuration set with @ref sd_ble_cfg_set. The default tag is @ref BLE_CONN_CFG_TAG_DEFAULT. */
 #define APP_BLE_OBSERVER_PRIO   3                                       /**< BLE observer priority of the application. There is no need to modify this value. */
-
-#define UART_TX_BUF_SIZE       1024                                     /**< UART TX buffer size. */
-#define UART_RX_BUF_SIZE       1024                                     /**< UART RX buffer size. */
 
 #define NUS_SERVICE_UUID_TYPE   BLE_UUID_TYPE_VENDOR_BEGIN              /**< UUID type for the Nordic UART Service (vendor specific). */
 
@@ -212,23 +211,6 @@ static void db_disc_handler(ble_db_discovery_evt_t * p_evt)
 }
 
 
-static ret_code_t write_uart(uint8_t value, char* string)
-{
-    ret_code_t ret_val;
-
-    do
-    {
-        ret_val = app_uart_put(value);
-        if ((ret_val != NRF_SUCCESS) && (ret_val != NRF_ERROR_BUSY))
-        {
-            NRF_LOG_ERROR("%s", string);
-        }
-    } while (ret_val == NRF_ERROR_BUSY);
-
-    return ret_val;
-}
-
-
 /**@brief Function for handling characters received by the Nordic UART Service (NUS).
  *
  * @details This function takes a list of characters of length data_len and prints the characters out on UART.
@@ -236,169 +218,46 @@ static ret_code_t write_uart(uint8_t value, char* string)
  */
 static void ble_nus_chars_received_uart_print(uint8_t * p_data, uint16_t data_len)
 {
-/*
     ret_code_t ret_val;
-
-    NRF_LOG_DEBUG("Receiving data.");
-    NRF_LOG_HEXDUMP_DEBUG(p_data, data_len);
-
-    for (uint32_t i = 0; i < data_len; i++)
-    {
-        do
-        {
-            ret_val = app_uart_put(p_data[i]);
-            if ((ret_val != NRF_SUCCESS) && (ret_val != NRF_ERROR_BUSY))
-            {
-                NRF_LOG_ERROR("app_uart_put failed for index 0x%04x.", i);
-                APP_ERROR_CHECK(ret_val);
-            }
-        } while (ret_val == NRF_ERROR_BUSY);
-    }
-    if (p_data[data_len-1] == '\r')
-    {
-        while (app_uart_put('\n') == NRF_ERROR_BUSY);
-    }
-    if (ECHOBACK_BLE_UART_DATA)
-    {
-        // Send data back to the peripheral.
-        do
-        {
-            ret_val = ble_nus_c_string_send(&m_ble_nus_c, p_data, data_len);
-            if ((ret_val != NRF_SUCCESS) && (ret_val != NRF_ERROR_BUSY))
-            {
-                NRF_LOG_ERROR("Failed sending NUS message. Error 0x%x. ", ret_val);
-                APP_ERROR_CHECK(ret_val);
-            }
-        } while (ret_val == NRF_ERROR_BUSY);
-    }
-*/
-
-    ret_code_t ret_val;
+    uint32_t i, j;
+    uint8_t data_array[m_ble_nus_max_data_len*5];
 
     char ascii[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
                       '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
-    for (uint32_t i = 0; i < data_len; i++)
+    for (i = 0, j = 0; i < data_len; i++)
     {
-        ret_val = write_uart('0', "app_uart_put failed for 0.");
-        ret_val = write_uart('x', "app_uart_put failed for x.");
-        do
-        {
-            uint32_t index = (p_data[i] & 0xf0) >> 4;
-            char character = ascii[index];
-            ret_val = app_uart_put(ascii[index]);
-            if ((ret_val != NRF_SUCCESS) && (ret_val != NRF_ERROR_BUSY))
-            {
-                NRF_LOG_ERROR("app_uart_put failed for index 0x%04x.", i);
-                //APP_ERROR_CHECK(ret_val);
-            }
-        } while (ret_val == NRF_ERROR_BUSY);
-        do
-        {
-            ret_val = app_uart_put(ascii[(p_data[i] & 0x0f)]);
-            if ((ret_val != NRF_SUCCESS) && (ret_val != NRF_ERROR_BUSY))
-            {
-                NRF_LOG_ERROR("app_uart_put failed for index 0x%04x.", i);
-                //APP_ERROR_CHECK(ret_val);
-            }
-        } while (ret_val == NRF_ERROR_BUSY);
-        ret_val = write_uart(' ', "app_uart_put failed for [space].");
+        data_array[j++] = '0';
+        data_array[j++] = 'x';
+        data_array[j++] = ascii[(p_data[i] & 0xf0) >> 4];
+        data_array[j++] = ascii[(p_data[i] & 0x0f) >> 0];
+        data_array[j++] = ' ';
     }
-    ret_val = write_uart('\r', "app_uart_put failed for \\r.");
-    ret_val = write_uart('\n', "app_uart_put failed for \\n.");
+    data_array[j++] = '\r';
+    data_array[j++] = '\n';
 
-/*
-    // This makes the output to the UART compatable with my python imu gui.
-    IMU_DATA *imu_data = (IMU_DATA*)p_data;
-    uint8_t message[128];
-    static uint32_t count = 0;
-    uint32_t i;
-    
-    // calling sprintf slows the system down tremendously.
-    sprintf((char*)message, 
-           "%ld: "
-           "ax = %d, ay = %d, az = %d, "
-           "gx = %d, gy = %d, gz = %d\r\n",
-           count++, imu_data->ax, imu_data->ay, imu_data->az, imu_data->gx, imu_data->gy, imu_data->gz);
-
-    i = 0;
-    do 
-    {
-        app_uart_put(message[i]);
-    } while (message[i++] != '\n');
-*/
+    output_string(data_array, j);
 }
 
 
-/**@brief   Function for handling app_uart events.
- *
- * @details This function receives a single character from the app_uart module and appends it to
- *          a string. The string is sent over BLE when the last character received is a
- *          'new line' '\n' (hex 0x0A) or if the string reaches the maximum data length.
- */
-void uart_event_handle(app_uart_evt_t * p_event)
+void ble_process_input_string_handler(char *data_array, uint32_t length)
 {
-    static uint8_t data_array[BLE_NUS_MAX_DATA_LEN];
-    static uint16_t index = 0;
+    uint16_t index = length;
     uint32_t ret_val;
 
-    switch (p_event->evt_type)
+    ret_val = NRF_SUCCESS;  // initialize to good value in case user input something other than r/s
+    if ((index >= 2) && ((data_array[0] == 'r') || (data_array[0] == 'R')))
     {
-        /**@snippet [Handling data from UART] */
-        case APP_UART_DATA_READY:
-            UNUSED_VARIABLE(app_uart_get(&data_array[index]));
-            index++;
-
-            if ((data_array[index - 1] == '\n') ||
-                (data_array[index - 1] == '\r') ||
-                (index >= (m_ble_nus_max_data_len)))
-            {
-                /*
-                NRF_LOG_DEBUG("Ready to send data over BLE NUS");
-                NRF_LOG_HEXDUMP_DEBUG(data_array, index);
-
-                do
-                {
-                    ret_val = ble_nus_c_string_send(&m_ble_nus_c, data_array, index);
-                    if ( (ret_val != NRF_ERROR_INVALID_STATE) && (ret_val != NRF_ERROR_RESOURCES) )
-                    {
-                        APP_ERROR_CHECK(ret_val);
-                    }
-                } while (ret_val == NRF_ERROR_RESOURCES);
-                */
-
-                ret_val = NRF_SUCCESS;  // initialize to good value in case user input something other than r/s
-                if ((index >= 2) && ((data_array[0] == 'r') || (data_array[0] == 'R')))
-                {
-                    ret_val = ble_nus_c_tx_notif_enable(&m_ble_nus_c, true);
-                }
-                else if ((index >= 2) && ((data_array[0] == 's') || (data_array[0] == 'S')))
-                {
-                    ret_val = ble_nus_c_tx_notif_enable(&m_ble_nus_c, false);
-                }
-                if ((ret_val != NRF_SUCCESS) && (ret_val != NRF_ERROR_BUSY))
-                {
-                    NRF_LOG_ERROR("ble_nus_c_tx_notif_enable() failed to set notify");
-                    APP_ERROR_CHECK(ret_val);
-                }
-
-                index = 0;
-            }
-            break;
-
-        /**@snippet [Handling data from UART] */
-        case APP_UART_COMMUNICATION_ERROR:
-            NRF_LOG_ERROR("Communication error occurred while handling UART.");
-            APP_ERROR_HANDLER(p_event->data.error_communication);
-            break;
-
-        case APP_UART_FIFO_ERROR:
-            NRF_LOG_ERROR("Error occurred in FIFO module used by UART.");
-            APP_ERROR_HANDLER(p_event->data.error_code);
-            break;
-
-        default:
-            break;
+        ret_val = ble_nus_c_tx_notif_enable(&m_ble_nus_c, true);
+    }
+    else if ((index >= 2) && ((data_array[0] == 's') || (data_array[0] == 'S')))
+    {
+        ret_val = ble_nus_c_tx_notif_enable(&m_ble_nus_c, false);
+    }
+    if ((ret_val != NRF_SUCCESS) && (ret_val != NRF_ERROR_BUSY))
+    {
+        NRF_LOG_ERROR("ble_nus_c_tx_notif_enable() failed to set notify");
+        APP_ERROR_CHECK(ret_val);
     }
 }
 
@@ -636,32 +495,6 @@ void bsp_event_handler(bsp_event_t event)
     }
 }
 
-/**@brief Function for initializing the UART. */
-static void uart_init(void)
-{
-    ret_code_t err_code;
-
-    app_uart_comm_params_t const comm_params =
-    {
-        .rx_pin_no    = RX_PIN_NUMBER,
-        .tx_pin_no    = TX_PIN_NUMBER,
-        .rts_pin_no   = RTS_PIN_NUMBER,
-        .cts_pin_no   = CTS_PIN_NUMBER,
-        .flow_control = APP_UART_FLOW_CONTROL_DISABLED,
-        .use_parity   = false,
-        .baud_rate    = UART_BAUDRATE_BAUDRATE_Baud115200
-    };
-
-    APP_UART_FIFO_INIT(&comm_params,
-                       UART_RX_BUF_SIZE,
-                       UART_TX_BUF_SIZE,
-                       uart_event_handle,
-                       APP_IRQ_PRIORITY_LOWEST,
-                       err_code);
-
-    APP_ERROR_CHECK(err_code);
-}
-
 /**@brief Function for initializing the Nordic UART Service (NUS) client. */
 static void nus_c_init(void)
 {
@@ -752,7 +585,7 @@ int main(void)
     // Initialize.
     log_init();
     timer_init();
-    uart_init();
+    uart_init(ble_process_input_string_handler);
     buttons_leds_init();
     db_discovery_init();
     power_management_init();
@@ -762,8 +595,7 @@ int main(void)
     scan_init();
 
     // Start execution.
-    printf("BLE UART central example started. printf()\r\n");
-    NRF_LOG_INFO("BLE UART central example started. NRF_LOG_INFO()");
+    NRF_LOG_INFO("BLE UART central example started.");
     scan_start();
 
     // Enter main loop.

--- a/ble_icm_20948_central/pca10059/s140/ses/ble_icm_20948_central_pca10059_s140.emProject
+++ b/ble_icm_20948_central/pca10059/s140/ses/ble_icm_20948_central_pca10059_s140.emProject
@@ -97,6 +97,7 @@
       <file file_name="../../../main.c" />
       <file file_name="../config/sdk_config.h" />
       <file file_name="../../../ble_nus_c.c" />
+      <file file_name="../../../uart.c" />
     </folder>
     <folder Name="nRF_Segger_RTT">
       <file file_name="../../../../../../external/segger_rtt/SEGGER_RTT.c" />

--- a/ble_icm_20948_central/uart.c
+++ b/ble_icm_20948_central/uart.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright(c) 2021 - Jim Newman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+//#include "nordic_common.h"
+#include "app_error.h"
+#include "app_uart.h"
+//#include "ble_db_discovery.h"
+//#include "app_timer.h"
+//#include "app_util.h"
+//#include "bsp_btn_ble.h"
+//#include "ble.h"
+//#include "ble_gap.h"
+//#include "ble_hci.h"
+//#include "nrf_sdh.h"
+//#include "nrf_sdh_ble.h"
+//#include "nrf_sdh_soc.h"
+#include "ble_nus_c.h"
+//#include "nrf_ble_gatt.h"
+//#include "nrf_pwr_mgmt.h"
+//#include "nrf_ble_scan.h"
+
+#include "nrf_log.h"
+#include "nrf_log_ctrl.h"
+#include "nrf_log_default_backends.h"
+
+#include "uart.h"
+
+#define UART_TX_BUF_SIZE       1024                                     /**< UART TX buffer size. */
+#define UART_RX_BUF_SIZE       1024                                     /**< UART RX buffer size. */
+
+ble_process_input_string_handler_t ble_process_input_string;
+
+/**@brief   Function for handling app_uart events.
+ *
+ * @details This function receives a single character from the app_uart module and appends it to
+ *          a string. The string is sent over BLE when the last character received is a
+ *          'new line' '\n' (hex 0x0A) or if the string reaches the maximum data length.
+ */
+void uart_event_handle(app_uart_evt_t * p_event)
+{
+    static uint8_t data_array[BLE_NUS_MAX_DATA_LEN];
+    static uint16_t index = 0;
+    uint32_t ret_val;
+
+    switch (p_event->evt_type)
+    {
+        /**@snippet [Handling data from UART] */
+        case APP_UART_DATA_READY:
+            UNUSED_VARIABLE(app_uart_get(&data_array[index]));
+            index++;
+
+            if (   (data_array[index - 1] == '\n')
+                || (data_array[index - 1] == '\r')
+                || (index >= BLE_NUS_MAX_DATA_LEN) )
+            {
+                // call function to process input string
+                ble_process_input_string(data_array, index);
+                index = 0;  // reset index for next string
+            }
+            break;
+
+        /**@snippet [Handling data from UART] */
+        case APP_UART_COMMUNICATION_ERROR:
+            NRF_LOG_ERROR("Communication error occurred while handling UART.");
+            APP_ERROR_HANDLER(p_event->data.error_communication);
+            break;
+
+        case APP_UART_FIFO_ERROR:
+            NRF_LOG_ERROR("Error occurred in FIFO module used by UART.");
+            APP_ERROR_HANDLER(p_event->data.error_code);
+            break;
+
+        default:
+            break;
+    }
+}
+
+
+void output_string(uint8_t *data_array, uint32_t length)
+{
+    ret_code_t ret_val;
+    uint32_t i;
+
+    for (i = 0; i < length; i++)
+    {
+        ret_val = app_uart_put(data_array[i]);
+        if ((ret_val != NRF_SUCCESS) && (ret_val != NRF_ERROR_BUSY))
+        {
+            NRF_LOG_ERROR("Error occured processing output string.");
+        }
+    }
+
+    return ret_val;
+}
+
+
+/**@brief Function for initializing the UART. */
+void uart_init(ble_process_input_string_handler_t ble_process_input_string_handler)
+{
+    ret_code_t err_code;
+
+    ble_process_input_string = ble_process_input_string_handler;
+
+    app_uart_comm_params_t const comm_params =
+    {
+        .rx_pin_no    = RX_PIN_NUMBER,
+        .tx_pin_no    = TX_PIN_NUMBER,
+        .rts_pin_no   = RTS_PIN_NUMBER,
+        .cts_pin_no   = CTS_PIN_NUMBER,
+        .flow_control = APP_UART_FLOW_CONTROL_DISABLED,
+        .use_parity   = false,
+        .baud_rate    = UART_BAUDRATE_BAUDRATE_Baud115200
+    };
+                       
+    app_uart_buffers_t buffers;
+    static uint8_t     rx_buf[UART_RX_BUF_SIZE];
+    static uint8_t     tx_buf[UART_TX_BUF_SIZE];
+
+    buffers.rx_buf      = rx_buf;
+    buffers.rx_buf_size = sizeof (rx_buf);
+    buffers.tx_buf      = tx_buf;
+    buffers.tx_buf_size = sizeof (tx_buf);
+    err_code = app_uart_init(&comm_params, &buffers, uart_event_handle, APP_IRQ_PRIORITY_LOWEST);
+
+    APP_ERROR_CHECK(err_code);
+}

--- a/ble_icm_20948_central/uart.h
+++ b/ble_icm_20948_central/uart.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright(c) 2021 - Jim Newman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef UART_H__
+#define UART_H__
+
+
+/**@brief DB Discovery event handler type. */
+typedef void (* ble_process_input_string_handler_t)(char *p_string, uint32_t length);
+
+//ret_code_t write_uart(uint8_t value, char* string);
+void uart_init(ble_process_input_string_handler_t ble_process_input_string_handler);
+
+void output_string(uint8_t *data_array, uint32_t length);
+
+#endif // UART_H__


### PR DESCRIPTION
Restructured code by moving the support for the uart to it's own module.  This is in preparation of adding usb support instead of uart for just the pca10059 dongle.  The intent is to have the code structured so that the host can be either the uart for all devices or usb for those devices that support usb.