### PR TITLE
Fix release build

### DIFF
--- a/ble_icm_20948_central/pca10059u/s140/armgcc/Makefile
+++ b/ble_icm_20948_central/pca10059u/s140/armgcc/Makefile
@@ -13,6 +13,7 @@ SRC_FILES += \
   $(SDK_ROOT)/modules/nrfx/mdk/gcc_startup_nrf52840.S \
   $(SDK_ROOT)/components/libraries/log/src/nrf_log_backend_rtt.c \
   $(SDK_ROOT)/components/libraries/log/src/nrf_log_backend_serial.c \
+  $(SDK_ROOT)/components/libraries/log/src/nrf_log_backend_uart.c \
   $(SDK_ROOT)/components/libraries/log/src/nrf_log_default_backends.c \
   $(SDK_ROOT)/components/libraries/log/src/nrf_log_frontend.c \
   $(SDK_ROOT)/components/libraries/log/src/nrf_log_str_formatter.c \

--- a/ble_icm_20948_central/pca10059u/s140/config/sdk_config.h
+++ b/ble_icm_20948_central/pca10059u/s140/config/sdk_config.h
@@ -7872,11 +7872,11 @@
 // <e> NRF_LOG_BACKEND_UART_ENABLED - nrf_log_backend_uart - Log UART backend
 //==========================================================
 #ifndef NRF_LOG_BACKEND_UART_ENABLED
-#define NRF_LOG_BACKEND_UART_ENABLED 0
+#define NRF_LOG_BACKEND_UART_ENABLED 1
 #endif
 // <o> NRF_LOG_BACKEND_UART_TX_PIN - UART TX pin 
 #ifndef NRF_LOG_BACKEND_UART_TX_PIN
-#define NRF_LOG_BACKEND_UART_TX_PIN 6
+#define NRF_LOG_BACKEND_UART_TX_PIN 17
 #endif
 
 // <o> NRF_LOG_BACKEND_UART_BAUDRATE  - Default Baudrate

--- a/ble_icm_20948_central/pca10059u/s140/ses/ble_icm_20948_central_pca10059u_s140.emProject
+++ b/ble_icm_20948_central/pca10059u/s140/ses/ble_icm_20948_central_pca10059u_s140.emProject
@@ -1,6 +1,9 @@
 <!DOCTYPE CrossStudio_Project_File>
-<solution Name="ble_icm_20948_central_pca10059_s140" target="8" version="2">
-  <project Name="ble_icm_20948_central_pca10059_s140">
+<solution
+  Name="ble_icm_20948_central_pca10059u_s140"
+  target="8"
+  version="2">
+  <project Name="ble_icm_20948_central_pca10059u_s140">
     <configuration
       Name="Common"
       arm_architecture="v7EM"


### PR DESCRIPTION
    The release build is running faster than the debug build.  This was causing the output array of characters to be over-written with the next string prior to the prior string being fully outputted.  The fix was to copy the string to a static array that gets sent out.

    Another fix would have been to create an array of strings and then index through the array with each output circling back to the first when the array reaches the end.
