### PR TITLE
Interface Enhancements

### DIFF
--- a/ble_icm_20948_central/ble_nus_c.c
+++ b/ble_icm_20948_central/ble_nus_c.c
@@ -349,6 +349,62 @@ uint32_t ble_nus_c_id_receive(ble_nus_c_t * p_ble_nus_c)
 }
 
 
+uint32_t ble_nus_c_tx_receive(ble_nus_c_t * p_ble_nus_c)
+{
+    VERIFY_PARAM_NOT_NULL(p_ble_nus_c);
+
+    ret_code_t err_code;
+    nrf_ble_gq_req_t read_req;
+
+    memset(&read_req, 0, sizeof(nrf_ble_gq_req_t));
+
+    if (p_ble_nus_c->conn_handle == BLE_CONN_HANDLE_INVALID)
+    {
+        NRF_LOG_WARNING("Connection handle invalid.");
+        return NRF_ERROR_INVALID_STATE;
+    }
+
+    read_req.type                        = NRF_BLE_GQ_REQ_GATTC_READ;
+    read_req.error_handler.cb            = gatt_error_handler;
+    read_req.error_handler.p_ctx         = p_ble_nus_c;
+    read_req.params.gattc_read.handle    = p_ble_nus_c->handles.nus_tx_handle;
+    read_req.params.gattc_read.offset    = 0;
+
+    err_code = nrf_ble_gq_item_add(p_ble_nus_c->p_gatt_queue, &read_req, p_ble_nus_c->conn_handle);
+    APP_ERROR_CHECK(err_code);
+
+    return err_code;
+}
+
+
+uint32_t ble_nus_c_fsr_receive(ble_nus_c_t * p_ble_nus_c)
+{
+    VERIFY_PARAM_NOT_NULL(p_ble_nus_c);
+
+    ret_code_t err_code;
+    nrf_ble_gq_req_t read_req;
+
+    memset(&read_req, 0, sizeof(nrf_ble_gq_req_t));
+
+    if (p_ble_nus_c->conn_handle == BLE_CONN_HANDLE_INVALID)
+    {
+        NRF_LOG_WARNING("Connection handle invalid.");
+        return NRF_ERROR_INVALID_STATE;
+    }
+
+    read_req.type                        = NRF_BLE_GQ_REQ_GATTC_READ;
+    read_req.error_handler.cb            = gatt_error_handler;
+    read_req.error_handler.p_ctx         = p_ble_nus_c;
+    read_req.params.gattc_read.handle    = p_ble_nus_c->handles.nus_rx_handle;
+    read_req.params.gattc_read.offset    = 0;
+
+    err_code = nrf_ble_gq_item_add(p_ble_nus_c->p_gatt_queue, &read_req, p_ble_nus_c->conn_handle);
+    APP_ERROR_CHECK(err_code);
+
+    return err_code;
+}
+
+
 uint32_t ble_nus_c_handles_assign(ble_nus_c_t               * p_ble_nus,
                                   uint16_t                    conn_handle,
                                   ble_nus_c_handles_t const * p_peer_handles)

--- a/ble_icm_20948_central/ble_nus_c.h
+++ b/ble_icm_20948_central/ble_nus_c.h
@@ -126,6 +126,7 @@ typedef enum
     BLE_NUS_C_EVT_DISCOVERY_COMPLETE,   /**< Event indicating that the NUS service and its characteristics were found. */
     BLE_NUS_C_EVT_NUS_TX_EVT,           /**< Event indicating that the central received something from a peer. */
     BLE_NUS_C_EVT_READ_RSP,             /**< Event indicating that the central recieved a read responce */
+    BLE_NUS_C_EVT_READ_FSR_RSP,         /**< Event indicating that the central recieved a read fsr responce */
     BLE_NUS_C_EVT_DISCONNECTED          /**< Event indicating that the NUS server disconnected. */
 } ble_nus_c_evt_type_t;
 
@@ -145,7 +146,7 @@ typedef struct
     ble_nus_c_evt_type_t evt_type;
     uint16_t             conn_handle;
     uint16_t             max_data_len;
-    uint8_t            * p_data;
+    uint8_t      const * p_data;
     uint16_t             data_len;
     ble_nus_c_handles_t  handles;     /**< Handles on which the Nordic UART service characteristics were discovered on the peer device. This is filled if the evt_type is @ref BLE_NUS_C_EVT_DISCOVERY_COMPLETE.*/
 } ble_nus_c_evt_t;
@@ -238,7 +239,11 @@ uint32_t ble_nus_c_tx_notif_enable(ble_nus_c_t * p_ble_nus_c, bool notify);
 
 uint32_t ble_nus_c_rx_notif_enable(ble_nus_c_t * p_ble_nus_c, bool notify);
 
+uint32_t ble_nus_c_tx_receive(ble_nus_c_t * p_ble_nus_c);
+
 uint32_t ble_nus_c_id_receive(ble_nus_c_t * p_ble_nus_c);
+
+uint32_t ble_nus_c_fsr_receive(ble_nus_c_t * p_ble_nus_c);
 
 /**@brief Function for sending a string to the server.
  *


### PR DESCRIPTION
Added the initialization of the array that holds the full scale resolutions for the accel, gyro, and mag by reading the values from the peripheral after the connection is made.

Added the ability to read a single imu data set.  But this only returns the last measurement that was made while the device was running; that is, only when notify is enabled.  The imu is downed down when notify is disabled to save power.

Corrected an annoying warning about const value.