### PR TITLE
Added Device ID to peripheral output messages

### DIFF
--- a/ble_icm_20948_peripheral/main.c
+++ b/ble_icm_20948_peripheral/main.c
@@ -829,6 +829,8 @@ int main(void)
 
     // start execution
     NRF_LOG_INFO("BLE IMU evaluation started.");
+    NRF_LOG_INFO("Device ID: %x", m_service.deviceid);
+
     //application_timers_start();
 
     advertising_start(erase_bonds);


### PR DESCRIPTION
Added the Device ID to the peripheral output messages to help when debugging the device id characteristic.  This also will help in determining the first four bytes in the imu data output characteristic.  